### PR TITLE
Support generating doc JSON

### DIFF
--- a/.github/workflows/asciidoc_json.yml
+++ b/.github/workflows/asciidoc_json.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  workflow_dispatch:
-  push:
-    branches: ["master", "codasip"]
+on: [workflow_dispatch]
 
 jobs:
   build:
@@ -22,5 +18,10 @@ jobs:
       run: |
         sudo mkdir -p /usr/local
         curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
-    - name: Build simulators
-      run: make -j4 c_emulator/cheri_riscv_sim_RV{32,64}
+    - name: Build Asciidoc JSON bundle
+      run: make sail_doc/riscv_RV64.json
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: riscv_RV64.json
+        path: sail_doc/riscv_RV64.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 generated_definitions
 z3_problems
 c_emulator
+/sail_doc

--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -196,7 +196,7 @@ function clause execute (GCBASE(rd, cs1)) = {
  *
  * gchi rd, cs1
  *
- * Copy the metadata (bits [CLEN-1:MXLEN]) of capability cs1 into rd.
+ * Copy the metadata (bits `[CLEN-1:MXLEN]`) of capability cs1 into rd.
  */
 function clause execute (GCHI(rd, cs1)) = {
   let capVal = C(cs1);
@@ -212,7 +212,7 @@ union clause ast = SCHI : (regidx, regidx, regidx)
  * schi cd, cs1, rs2
  *
  * Copy cs1  to cd , replace the capability metadata (i.e. bits
- * [CLEN-1:MXLEN]) with rs2  and set cd.tag to 0.
+ * `[CLEN-1:MXLEN]`) with rs2  and set cd.tag to 0.
  */
 function clause execute (SCHI(cd, cs1, rs2)) = {
   let capVal = C(cs1);


### PR DESCRIPTION
* Copy `sail_doc` target from `sail-riscv/Makefile` to CHERI `Makefile`
* Update `compile.yml` to match `sail-riscv`'s and add a workflow to generate the doc JSON
* Fix a few comments that Sail chokes on because it can't convert the Markdown to Asciidoc.